### PR TITLE
Add support to skip first token in subject

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -140,6 +140,14 @@ validate_commit_message() {
   # if the commit subject starts with 'fixup! ' there's nothing to validate, we can return here
   [[ $COMMIT_SUBJECT == 'fixup! '* ]] && return;
 
+  # skip first token in subject (e.g. issue ID from bugtracker which is validated otherwise)
+  skipfirsttokeninsubject=$(git config --get hooks.goodcommit.subjectskipfirsttoken || echo 'false')
+  if [ "$skipfirsttokeninsubject" == "true" ]; then
+    COMMIT_SUBJECT_TO_PROCESS=${COMMIT_SUBJECT#* }
+  else
+    COMMIT_SUBJECT_TO_PROCESS=$COMMIT_SUBJECT
+  fi
+    
   # 1. Separate subject from body with a blank line
   # ------------------------------------------------------------------------------
 
@@ -155,7 +163,7 @@ validate_commit_message() {
   # 3. Capitalize the subject line
   # ------------------------------------------------------------------------------
 
-  [[ ${COMMIT_SUBJECT} =~ ^[[:blank:]]*([[:upper:]]{1}[[:lower:]]*|[[:digit:]]+)([[:blank:]]|[[:punct:]]|$) ]]
+  [[ ${COMMIT_SUBJECT_TO_PROCESS} =~ ^[[:blank:]]*([[:upper:]]{1}[[:lower:]]*|[[:digit:]]+)([[:blank:]]|[[:punct:]]|$) ]]
   test $? -eq 0 || add_warning 1 "Capitalize the subject line"
 
   # 4. Do not end the subject line with a period
@@ -228,7 +236,7 @@ validate_commit_message() {
   shopt -s nocasematch
 
   for BLACKLISTED_WORD in "${IMPERATIVE_MOOD_BLACKLIST[@]}"; do
-    [[ ${COMMIT_SUBJECT} =~ ^[[:blank:]]*$BLACKLISTED_WORD ]]
+    [[ ${COMMIT_SUBJECT_TO_PROCESS} =~ ^[[:blank:]]*$BLACKLISTED_WORD ]]
     test $? -eq 0 && add_warning 1 "Use the imperative mood in the subject line, e.g 'fix' not 'fixes'" && break
   done
 
@@ -254,14 +262,14 @@ validate_commit_message() {
   # 8. Do no write single worded commits
   # ------------------------------------------------------------------------------
 
-  COMMIT_SUBJECT_WORDS=(${COMMIT_SUBJECT})
+  COMMIT_SUBJECT_WORDS=(${COMMIT_SUBJECT_TO_PROCESS})
   test "${#COMMIT_SUBJECT_WORDS[@]}" -gt 1
   test $? -eq 0 || add_warning 1 "Do no write single worded commits"
 
   # 9. Do not start the subject line with whitespace
   # ------------------------------------------------------------------------------
 
-  [[ ${COMMIT_SUBJECT} =~ ^[[:blank:]]+ ]]
+  [[ ${COMMIT_SUBJECT_TO_PROCESS} =~ ^[[:blank:]]+ ]]
   test $? -eq 1 || add_warning 1 "Do not start the subject line with whitespace"
 }
 


### PR DESCRIPTION
First token in subject might be a bugtracker issue ID which is validated in another hook. Behavior can be configured using git config.